### PR TITLE
docs: fix typos across deployment documentation

### DIFF
--- a/AWS/Open RAN SIM CE 1.0/Deployment Tools/cloudformation/README.md
+++ b/AWS/Open RAN SIM CE 1.0/Deployment Tools/cloudformation/README.md
@@ -2,11 +2,11 @@
 
 ## Prerequisites
 The prerequisites are:
-- Key pair for accessing to LoadCore instances
+- Key pair for accessing LoadCore instances
 - An existing VPC
 - An existing management subnet with internet access for accessing the LoadCore UI
 - For some of the templates, you will need an existing test subnet
-- existing Security Groups that allows HTTP/HTTPs traffic on inbound (for accessing the LoadCore UI), allows the traffic between LoadCore and LoadCore agents for management purposes and allows the test traffic
+- existing Security Groups that allow HTTP/HTTPs traffic on inbound (for accessing the LoadCore UI), allows the traffic between LoadCore and LoadCore agents for management purposes and allows the test traffic
 
 ## Description of Cloudformation Templates
 
@@ -14,31 +14,31 @@ The prerequisites are:
 Name: loadcore_two_agents_and_license_server.json
 The template deploys:
 - One LoadCore in the management subnet
-- Two LoadCore Agents with two interfaces each. The first interface will be used for mananagament and the second interface will be used for testing
-- One LoadCode License Server in the management subnet
+- Two LoadCore Agents with two interfaces each. The first interface will be used for management and the second interface will be used for testing
+- One LoadCore License Server in the management subnet
 
-When deleting the stack, the License Server will be skipped and the user should first de-activate the licenses before manually terminating the instance. This will prevent the licenses to remain activated on a deleted instance.
+When deleting the stack, the License Server will be skipped and the user should first de-activate the licenses before manually terminating the instance. This will prevent the licenses from remaining activated on a deleted instance.
 
 ### LoadCore and two LoadCore Agents
 Name: loadcore_and_two_agents.json
 The template deploys:
 - One LoadCore in the management subnet
-- Two LoadCore Agents with two interfaces each. The first interface will be used for mananagament and the second interface will be used for testing
+- Two LoadCore Agents with two interfaces each. The first interface will be used for management and the second interface will be used for testing
 
 ### LoadCore, two LoadCore Agents, License Server and one custom test subnet
 Name: loadcore_two_agents_license_server_test_subnet.json
 The template deploys:
 - One LoadCore in the management subnet
-- Two LoadCore Agents with two interfaces each. The first interface will be used for mananagament and the second interface will be used for testing
+- Two LoadCore Agents with two interfaces each. The first interface will be used for management and the second interface will be used for testing
 - It will create a new test subnet which will be used as test subnet for the two LoadCore Agents.
 
 ### LoadCore and three LoadCore Agents
 Name: loadcore_three_agents_and_license_server.json
 The template deploys:
 - One LoadCore in the management subnet
-- Three LoadCore Agents with two interfaces each. The first interface will be used for mananagament and the second interface will be used for testing
+- Three LoadCore Agents with two interfaces each. The first interface will be used for management and the second interface will be used for testing
 - This setup can be used when planning to run tests with Application traffic (Raw Sockets)
-- One LoadCode License Server in the management subnet
+- One LoadCore License Server in the management subnet
 
 ### Deploying LoadCore, two LoadCore Agents, a License Server and the AWS infrastructure
 Name: loadcore_two_agents_license_server_full_setup.json
@@ -48,11 +48,11 @@ The template deploys:
 - Creates and attaches an internet gateway to the management subnet for internet access
 - Create two subnets: one for management (10.0.0.0/24 CIDR) and one for testing (20.0.0.0/16 CIDR)
 - One LoadCore in the management subnet
-- Two LoadCore Agents with two interfaces each. The first interface will be used for mananagament and the second interface will be used for testing
-- One LoadCode License Server in the management subnet
+- Two LoadCore Agents with two interfaces each. The first interface will be used for management and the second interface will be used for testing
+- One LoadCore License Server in the management subnet
 
 When deleting the stack, the License Server will be also deleted along with the activated licenses.
-The user should first de-activate the licenses before manually terminating the instance. This will prevent the licenses to remain activated on a deleted instance.
+The user should first de-activate the licenses before manually terminating the instance. This will prevent the licenses from remaining activated on a deleted instance.
 By default, the License Server Volume will not be deleted along with the instance for recovery purposes.
 ## Troubleshooting and Limitations
 

--- a/AWS/Open RAN SIM CE 1.0/Deployment Tools/cloudformation/loadcore_and_two_agents/README.md
+++ b/AWS/Open RAN SIM CE 1.0/Deployment Tools/cloudformation/loadcore_and_two_agents/README.md
@@ -2,7 +2,7 @@
 
 The template deploys:
 - One LoadCore in the management subnet
-- Two LoadCore Agents with two interfaces each. The first interface will be used for mananagament and the second interface will be used for testing
+- Two LoadCore Agents with two interfaces each. The first interface will be used for management and the second interface will be used for testing
 
 The following table lists the parameters for this deployment.
 

--- a/AWS/Open RAN SIM CE 1.0/Deployment Tools/cloudformation/loadcore_three_agents_and_license_server/README.md
+++ b/AWS/Open RAN SIM CE 1.0/Deployment Tools/cloudformation/loadcore_three_agents_and_license_server/README.md
@@ -2,11 +2,11 @@
 
 The template deploys:
 - One LoadCore in the management subnet
-- Three LoadCore Agents with two interfaces each. The first interface will be used for mananagament and the second interface will be used for testing
+- Three LoadCore Agents with two interfaces each. The first interface will be used for management and the second interface will be used for testing
 - This setup can be used when planning to run tests with Application traffic (Raw Sockets)
-- One LoadCode License Server in the management subnet
+- One LoadCore License Server in the management subnet
 
-When deleting the stack, the License Server will be skipped and the user should first de-activate the licenses before manually terminating the instance. This will prevent the licenses to remain activated on a deleted instance.
+When deleting the stack, the License Server will be skipped and the user should first de-activate the licenses before manually terminating the instance. This will prevent the licenses from remaining activated on a deleted instance.
 
 The following table lists the parameters for this deployment.
 

--- a/AWS/Open RAN SIM CE 1.0/Deployment Tools/cloudformation/loadcore_two_agents_and_license_server/README.md
+++ b/AWS/Open RAN SIM CE 1.0/Deployment Tools/cloudformation/loadcore_two_agents_and_license_server/README.md
@@ -2,10 +2,10 @@
 
 The template deploys:
 - One LoadCore in the management subnet
-- Two LoadCore Agents with two interfaces each. The first interface will be used for mananagament and the second interface will be used for testing
-- One LoadCode License Server in the management subnet
+- Two LoadCore Agents with two interfaces each. The first interface will be used for management and the second interface will be used for testing
+- One LoadCore License Server in the management subnet
 
-When deleting the stack, the License Server will be skipped and the user should first de-activate the licenses before manually terminating the instance. This will prevent the licenses to remain activated on a deleted instance.
+When deleting the stack, the License Server will be skipped and the user should first de-activate the licenses before manually terminating the instance. This will prevent the licenses from remaining activated on a deleted instance.
 
 The following table lists the parameters for this deployment.
 

--- a/AWS/Open RAN SIM CE 1.0/Deployment Tools/cloudformation/loadcore_two_agents_and_license_server_full_setup/README.md
+++ b/AWS/Open RAN SIM CE 1.0/Deployment Tools/cloudformation/loadcore_two_agents_and_license_server_full_setup/README.md
@@ -6,15 +6,15 @@ The template deploys:
 - Creates and attaches an internet gateway to the management subnet for internet access
 - Create two subnets: one for management (10.0.0.0/24 CIDR) and one for testing (20.0.0.0/16 CIDR)
 - One LoadCore in the management subnet
-- Two LoadCore Agents with two interfaces each. The first interface will be used for mananagament and the second interface will be used for testing
-- One LoadCode License Server in the management subnet
+- Two LoadCore Agents with two interfaces each. The first interface will be used for management and the second interface will be used for testing
+- One LoadCore License Server in the management subnet
 
 The LoadCore Agents will also have multiple private IPs to be used in testing:
 Agent1 Private IP Addresses: "20.0.4.12, 20.0.4.13, 20.0.4.14, 20.0.4.15, 20.0.4.16, 20.0.4.17, 20.0.4.18, 20.0.4.19, 20.0.4.20, 20.0.4.21"
 Agent2 Private IP Addresses: "20.0.5.12, 20.0.5.13, 20.0.5.14, 20.0.5.15, 20.0.5.16, 20.0.5.17, 20.0.5.18, 20.0.5.19, 20.0.5.20, 20.0.5.21"
 
 IMPORTANT!!! When deleting the stack, the License Server will be also deleted along with the activated licenses.
-The user should first de-activate the licenses before manually terminating the instance. This will prevent the licenses to remain activated on a deleted instance.
+The user should first de-activate the licenses before manually terminating the instance. This will prevent the licenses from remaining activated on a deleted instance.
 By default, the License Server Volume will not be deleted along with the instance for recovery purposes.
 
 The following table lists the parameters for this deployment.

--- a/AWS/Open RAN SIM CE 1.0/Deployment Tools/cloudformation/loadcore_two_agents_license_server_test_subnet/README.md
+++ b/AWS/Open RAN SIM CE 1.0/Deployment Tools/cloudformation/loadcore_two_agents_license_server_test_subnet/README.md
@@ -2,14 +2,14 @@
 
 The template deploys:
 - One LoadCore in the management subnet
-- Two LoadCore Agents with two interfaces each. The first interface will be used for mananagament and the second interface will be used for testing
+- Two LoadCore Agents with two interfaces each. The first interface will be used for management and the second interface will be used for testing
 - It will create a new test subnet which will be used as test subnet for the two LoadCore Agents. Ten private IPs will be automatically added on test interface on each Agent to be used in tests.
 
 Subnet CIDR: 20.0.0.0/16
 Agent1 Private IP Addresses: "20.0.4.12, 20.0.4.13, 20.0.4.14, 20.0.4.15, 20.0.4.16, 20.0.4.17, 20.0.4.18, 20.0.4.19, 20.0.4.20, 20.0.4.21"
 Agent2 Private IP Addresses: "20.0.5.12, 20.0.5.13, 20.0.5.14, 20.0.5.15, 20.0.5.16, 20.0.5.17, 20.0.5.18, 20.0.5.19, 20.0.5.20, 20.0.5.21"
 
-When deleting the stack, the License Server will be skipped and the user should first de-activate the licenses before manually terminating the instance. This will prevent the licenses to remain activated on a deleted instance.
+When deleting the stack, the License Server will be skipped and the user should first de-activate the licenses before manually terminating the instance. This will prevent the licenses from remaining activated on a deleted instance.
 
 The following table lists the parameters for this deployment.
 

--- a/AWS/Open RAN SIM CE 1.0/Deployment Tools/terraform/README.md
+++ b/AWS/Open RAN SIM CE 1.0/Deployment Tools/terraform/README.md
@@ -21,20 +21,20 @@ The  **terraform apply**  command executes the actions proposed in a terraform t
 Folder Name: loadcore_two_agents_and_license_server
 The template deploys:
 - One LoadCore in the management subnet
-- Two LoadCore Agents with two interfaces each. The first interface will be used for mananagament and the second interface will be used for testing
-- One LoadCode License Server in the management subnet
+- Two LoadCore Agents with two interfaces each. The first interface will be used for management and the second interface will be used for testing
+- One LoadCore License Server in the management subnet
 
 ### LoadCore, two LoadCore Agents and the AWS infrastructure
 Folder Name: loadcore_and_two_agents_full_setup
 The template deploys:
 - The AWS infrastructure: vpc, subnets, internet gateway, security groups.
 - One LoadCore in the management subnet
-- Two LoadCore Agents with two interfaces each. The first interface will be used for mananagament and the second interface will be used for testing
+- Two LoadCore Agents with two interfaces each. The first interface will be used for management and the second interface will be used for testing
 
 ### LoadCore, two LoadCore Agents, the License Server and the AWS infrastructure
 Folder Name: loadcore_two_agents_and_license_server_full_setup
 The template deploys:
 - The AWS infrastructure: vpc, subnets, internet gateway, security groups.
 - One LoadCore in the management subnet
-- Two LoadCore Agents with two interfaces each. The first interface will be used for mananagament and the second interface will be used for testing
-- One LoadCode License Server in the management subnet
+- Two LoadCore Agents with two interfaces each. The first interface will be used for management and the second interface will be used for testing
+- One LoadCore License Server in the management subnet

--- a/AWS/Open RAN SIM CE 1.0/Deployment Tools/terraform/loadcore_and_two_agents_full_setup/README.md
+++ b/AWS/Open RAN SIM CE 1.0/Deployment Tools/terraform/loadcore_and_two_agents_full_setup/README.md
@@ -3,7 +3,7 @@
 The template deploys:
 - The AWS infrastructure: vpc, subnets, internet gateway, security groups.
 - One LoadCore in the management subnet
-- Two LoadCore Agents with two interfaces each. The first interface will be used for mananagament and the second interface will be used for testing
+- Two LoadCore Agents with two interfaces each. The first interface will be used for management and the second interface will be used for testing
 
 The folder contains three files:
 **main.tf** contains the main set of configuration
@@ -19,7 +19,7 @@ In order to modify the default values, you should modify the **terraform.tfvars*
 | aws_secret_key  | Requires input | The AWS secret key must be obtained using following specification https://docs.aws.amazon.com/powershell/latest/userguide/pstools-appendix-sign-up.html. |
 | stack_name | Requires input |The AWS stack name. |
 | ssh_key | Requires input | Specify an existing AWS SSH key name. |
-| allowed_cidr | ["0.0.0.0/0"] |List of ip allowed to access the deployed machines. Default value will provide access to everyone from the internet. |
+| allowed_cidr | ["0.0.0.0/0"] |List of IPs allowed to access the deployed machines. Default value will provide access to everyone from the internet. |
 | region            | us-east-1   | The AWS region for deployment. |
 | availability_zone      | us-east-1a       | The AWS availability zone for deployment. |
 | vpc_cidr      | "20.0.0.0/16"      | The VPC CIDR. |

--- a/AWS/Open RAN SIM CE 1.0/Deployment Tools/terraform/loadcore_two_agents_and_license_server/README.md
+++ b/AWS/Open RAN SIM CE 1.0/Deployment Tools/terraform/loadcore_two_agents_and_license_server/README.md
@@ -2,8 +2,8 @@
 
 The template deploys:
 - One LoadCore in the management subnet
-- Two LoadCore Agents with two interfaces each. The first interface will be used for mananagament and the second interface will be used for testing
-- One LoadCode License Server in the management subnet
+- Two LoadCore Agents with two interfaces each. The first interface will be used for management and the second interface will be used for testing
+- One LoadCore License Server in the management subnet
 
 The AWS infrastructure should already exist in order to use this terraform template.
 
@@ -42,7 +42,7 @@ Other variables that can be modified in **variables.tf** file.
 ## Destruction
 
 When destroying the infrastructure, the License Server will be also deleted along with the activated licenses.
-The user should first de-activate the licenses before destroying the infrastructure. This will prevent the licenses to remain activated on a deleted instance.
+The user should first de-activate the licenses before destroying the infrastructure. This will prevent the licenses from remaining activated on a deleted instance.
 
 The **terraform destroy** command will destroy the previous deployed infrastructure.
 

--- a/AWS/Open RAN SIM CE 1.0/Deployment Tools/terraform/loadcore_two_agents_and_license_server_full_setup/README.md
+++ b/AWS/Open RAN SIM CE 1.0/Deployment Tools/terraform/loadcore_two_agents_and_license_server_full_setup/README.md
@@ -3,8 +3,8 @@
 The template deploys:
 - The AWS infrastructure: vpc, subnets, internet gateway, security groups.
 - One LoadCore in the management subnet
-- Two LoadCore Agents with two interfaces each. The first interface will be used for mananagament and the second interface will be used for testing
-- One LoadCode License Server in the management subnet
+- Two LoadCore Agents with two interfaces each. The first interface will be used for management and the second interface will be used for testing
+- One LoadCore License Server in the management subnet
 
 The folder contains three files:
 **main.tf** contains the main set of configuration
@@ -20,7 +20,7 @@ In order to modify the default values, you should modify the **terraform.tfvars*
 | aws_secret_key  | Requires input | The AWS secret key must be obtained using following specification https://docs.aws.amazon.com/powershell/latest/userguide/pstools-appendix-sign-up.html. |
 | stack_name | Requires input |The AWS stack name. |
 | ssh_key | Requires input | Specify an existing AWS SSH key name. |
-| allowed_cidr | ["0.0.0.0/0"] |List of ip allowed to access the deployed machines. Default value will provide access to everyone from the internet. |
+| allowed_cidr | ["0.0.0.0/0"] |List of IPs allowed to access the deployed machines. Default value will provide access to everyone from the internet. |
 | region            | us-east-1   | The AWS region for deployment. |
 | availability_zone      | us-east-1a       | The AWS availability zone for deployment. |
 | vpc_cidr      | "20.0.0.0/16"      | The VPC CIDR. |
@@ -41,7 +41,7 @@ Other variables that can be modified in **variables.tf** file.
 ## Destruction
 
 When destroying the infrastructure, the License Server will be also deleted along with the activated licenses.
-The user should first de-activate the licenses before destroying the infrastructure. This will prevent the licenses to remain activated on a deleted instance.
+The user should first de-activate the licenses before destroying the infrastructure. This will prevent the licenses from remaining activated on a deleted instance.
 
 The **terraform destroy** command will destroy the previous deployed infrastructure.
 

--- a/Azure/Open RAN SIM CE 1.0/terraform/deploy_LoadCore_from_Azure_Images/README.md
+++ b/Azure/Open RAN SIM CE 1.0/terraform/deploy_LoadCore_from_Azure_Images/README.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 The prerequisites are:
 - Latest version of Terraform installed. https://learn.hashicorp.com/tutorials/terraform/install-cli
-- Authenticate to Azure platform usign Azure CLI tool. https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli
+- Authenticate to Azure platform using Azure CLI tool. https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli
 
 ## How to use:
 
@@ -21,7 +21,7 @@ The  **terraform apply**  command executes the actions proposed in a terraform t
 
 The template deploys Virtual Machine using **Azure Images**:
 - One LoadCore MDW
-- Two LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Two LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 Each test interface will get 8 private IPs.
 
 The folder contains three files:
@@ -40,7 +40,7 @@ In order to modify the default values, you should modify the **terraform.tfvars*
 | ----------------------- | ----------------- | ----- |
 | prefix | Requires input |The Azure stack name. |
 | ssh_key_name | Requires input | Specify an existing Azure SSH key name. |
-| allowed_cidr | ["0.0.0.0/0"] |List of ip allowed to access the deployed machines. Default value will provide access to everyone from the internet. |
+| allowed_cidr | ["0.0.0.0/0"] |List of IPs allowed to access the deployed machines. Default value will provide access to everyone from the internet. |
 | location            | "eastus"   | The Azure region for deployment. |
 | images_resource_group_name     | Requires input   | The Azure resource group name |
 | loadcore_mdw_name     | Requires input   | The Azure Image name for LoadCore MDW |

--- a/Azure/Open RAN SIM CE 1.0/terraform/deploy_LoadCore_from_vhds/README.md
+++ b/Azure/Open RAN SIM CE 1.0/terraform/deploy_LoadCore_from_vhds/README.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 The prerequisites are:
 - Latest version of Terraform installed. https://learn.hashicorp.com/tutorials/terraform/install-cli
-- Authenticate to Azure platform usign Azure CLI tool. https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli
+- Authenticate to Azure platform using Azure CLI tool. https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli
 
 ## How to use:
 
@@ -21,7 +21,7 @@ The  **terraform apply**  command executes the actions proposed in a terraform t
 
 The template deploys Virtual Machine using **VHD files**:
 - One LoadCore MDW
-- Two LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Two LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 Each test interface will get 8 private IPs.
 
 The folder contains three files:
@@ -40,7 +40,7 @@ In order to modify the default values, you should modify the **terraform.tfvars*
 | ----------------------- | ----------------- | ----- |
 | prefix | Requires input |The Azure stack name. |
 | ssh_key_name | Requires input | Specify an existing Azure SSH key name. |
-| allowed_cidr | ["0.0.0.0/0"] |List of ip allowed to access the deployed machines. Default value will provide access to everyone from the internet. |
+| allowed_cidr | ["0.0.0.0/0"] |List of IPs allowed to access the deployed machines. Default value will provide access to everyone from the internet. |
 | location            | "eastus"   | The Azure region for deployment. |
 | loadcore_mdw_blob_uri     | Requires input   | The full blob uri where the vhd exists |
 | loadcore_agent_blob_uri     | Requires input   | The full blob uri where the vhd exists |

--- a/Azure/Open RAN SIM CE 2.0/terraform/deploy_LoadCore_from_Azure_Images/README.md
+++ b/Azure/Open RAN SIM CE 2.0/terraform/deploy_LoadCore_from_Azure_Images/README.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 The prerequisites are:
 - Latest version of Terraform installed. https://learn.hashicorp.com/tutorials/terraform/install-cli
-- Authenticate to Azure platform usign Azure CLI tool. https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli
+- Authenticate to Azure platform using Azure CLI tool. https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli
 
 ## How to use:
 
@@ -21,7 +21,7 @@ The  **terraform apply**  command executes the actions proposed in a terraform t
 
 The template deploys Virtual Machine using **Azure Images**:
 - One LoadCore MDW
-- Two LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Two LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 Each test interface will get 8 private IPs.
 
 The folder contains three files:
@@ -40,7 +40,7 @@ In order to modify the default values, you should modify the **terraform.tfvars*
 | ----------------------- | ----------------- | ----- |
 | prefix | Requires input |The Azure stack name. |
 | ssh_key_name | Requires input | Specify an existing Azure SSH key name. |
-| allowed_cidr | ["0.0.0.0/0"] |List of ip allowed to access the deployed machines. Default value will provide access to everyone from the internet. |
+| allowed_cidr | ["0.0.0.0/0"] |List of IPs allowed to access the deployed machines. Default value will provide access to everyone from the internet. |
 | location            | "eastus"   | The Azure region for deployment. |
 | images_resource_group_name     | Requires input   | The Azure resource group name |
 | loadcore_mdw_name     | Requires input   | The Azure Image name for LoadCore MDW |

--- a/Azure/Open RAN SIM CE 2.0/terraform/deploy_LoadCore_from_vhds/README.md
+++ b/Azure/Open RAN SIM CE 2.0/terraform/deploy_LoadCore_from_vhds/README.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 The prerequisites are:
 - Latest version of Terraform installed. https://learn.hashicorp.com/tutorials/terraform/install-cli
-- Authenticate to Azure platform usign Azure CLI tool. https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli
+- Authenticate to Azure platform using Azure CLI tool. https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli
 
 ## How to use:
 
@@ -21,7 +21,7 @@ The  **terraform apply**  command executes the actions proposed in a terraform t
 
 The template deploys Virtual Machine using **VHD files**:
 - One LoadCore MDW
-- Two LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Two LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 Each test interface will get 8 private IPs.
 
 The folder contains three files:
@@ -40,7 +40,7 @@ In order to modify the default values, you should modify the **terraform.tfvars*
 | ----------------------- | ----------------- | ----- |
 | prefix | Requires input |The Azure stack name. |
 | ssh_key_name | Requires input | Specify an existing Azure SSH key name. |
-| allowed_cidr | ["0.0.0.0/0"] |List of ip allowed to access the deployed machines. Default value will provide access to everyone from the internet. |
+| allowed_cidr | ["0.0.0.0/0"] |List of IPs allowed to access the deployed machines. Default value will provide access to everyone from the internet. |
 | location            | "eastus"   | The Azure region for deployment. |
 | loadcore_mdw_blob_uri     | Requires input   | The full blob uri where the vhd exists |
 | loadcore_agent_blob_uri     | Requires input   | The full blob uri where the vhd exists |

--- a/Azure/Open RAN SIM CE 3.0/terraform/deploy_LoadCore_from_Azure_Images/README.md
+++ b/Azure/Open RAN SIM CE 3.0/terraform/deploy_LoadCore_from_Azure_Images/README.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 The prerequisites are:
 - Latest version of Terraform installed. https://learn.hashicorp.com/tutorials/terraform/install-cli
-- Authenticate to Azure platform usign Azure CLI tool. https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli
+- Authenticate to Azure platform using Azure CLI tool. https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli
 
 ## How to use:
 
@@ -21,7 +21,7 @@ The  **terraform apply**  command executes the actions proposed in a terraform t
 
 The template deploys Virtual Machine using **Azure Images**:
 - One LoadCore MDW
-- Two LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Two LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 Each test interface will get 8 private IPs.
 
 The folder contains three files:
@@ -40,7 +40,7 @@ In order to modify the default values, you should modify the **terraform.tfvars*
 | ----------------------- | ----------------- | ----- |
 | prefix | Requires input |The Azure stack name. |
 | ssh_key_name | Requires input | Specify an existing Azure SSH key name. |
-| allowed_cidr | ["0.0.0.0/0"] |List of ip allowed to access the deployed machines. Default value will provide access to everyone from the internet. |
+| allowed_cidr | ["0.0.0.0/0"] |List of IPs allowed to access the deployed machines. Default value will provide access to everyone from the internet. |
 | location            | "eastus"   | The Azure region for deployment. |
 | images_resource_group_name     | Requires input   | The Azure resource group name |
 | loadcore_mdw_name     | Requires input   | The Azure Image name for LoadCore MDW |

--- a/Azure/Open RAN SIM CE 3.0/terraform/deploy_LoadCore_from_vhds/README.md
+++ b/Azure/Open RAN SIM CE 3.0/terraform/deploy_LoadCore_from_vhds/README.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 The prerequisites are:
 - Latest version of Terraform installed. https://learn.hashicorp.com/tutorials/terraform/install-cli
-- Authenticate to Azure platform usign Azure CLI tool. https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli
+- Authenticate to Azure platform using Azure CLI tool. https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli
 
 ## How to use:
 
@@ -21,7 +21,7 @@ The  **terraform apply**  command executes the actions proposed in a terraform t
 
 The template deploys Virtual Machine using **VHD files**:
 - One LoadCore MDW
-- Two LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Two LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 Each test interface will get 8 private IPs.
 
 The folder contains three files:
@@ -40,7 +40,7 @@ In order to modify the default values, you should modify the **terraform.tfvars*
 | ----------------------- | ----------------- | ----- |
 | prefix | Requires input |The Azure stack name. |
 | ssh_key_name | Requires input | Specify an existing Azure SSH key name. |
-| allowed_cidr | ["0.0.0.0/0"] |List of ip allowed to access the deployed machines. Default value will provide access to everyone from the internet. |
+| allowed_cidr | ["0.0.0.0/0"] |List of IPs allowed to access the deployed machines. Default value will provide access to everyone from the internet. |
 | location            | "eastus"   | The Azure region for deployment. |
 | loadcore_mdw_blob_uri     | Requires input   | The full blob uri where the vhd exists |
 | loadcore_agent_blob_uri     | Requires input   | The full blob uri where the vhd exists |

--- a/Azure/Open RAN SIM CE 5.0/terraform/deploy_LoadCore_from_Azure_Images/README.md
+++ b/Azure/Open RAN SIM CE 5.0/terraform/deploy_LoadCore_from_Azure_Images/README.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 The prerequisites are:
 - Latest version of Terraform installed. https://learn.hashicorp.com/tutorials/terraform/install-cli
-- Authenticate to Azure platform usign Azure CLI tool. https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli
+- Authenticate to Azure platform using Azure CLI tool. https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli
 
 ## How to use:
 
@@ -21,7 +21,7 @@ The  **terraform apply**  command executes the actions proposed in a terraform t
 
 The template deploys Virtual Machine using **Azure Images**:
 - One LoadCore MDW
-- Two LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Two LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 Each test interface will get 8 private IPs.
 
 The folder contains three files:
@@ -40,7 +40,7 @@ In order to modify the default values, you should modify the **terraform.tfvars*
 | ----------------------- | ----------------- | ----- |
 | prefix | Requires input |The Azure stack name. |
 | ssh_key_name | Requires input | Specify an existing Azure SSH key name. |
-| allowed_cidr | ["0.0.0.0/0"] |List of ip allowed to access the deployed machines. Default value will provide access to everyone from the internet. |
+| allowed_cidr | ["0.0.0.0/0"] |List of IPs allowed to access the deployed machines. Default value will provide access to everyone from the internet. |
 | location            | "eastus"   | The Azure region for deployment. |
 | images_resource_group_name     | Requires input   | The Azure resource group name |
 | loadcore_mdw_name     | Requires input   | The Azure Image name for LoadCore MDW |

--- a/Azure/Open RAN SIM CE 5.0/terraform/deploy_LoadCore_from_vhds/README.md
+++ b/Azure/Open RAN SIM CE 5.0/terraform/deploy_LoadCore_from_vhds/README.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 The prerequisites are:
 - Latest version of Terraform installed. https://learn.hashicorp.com/tutorials/terraform/install-cli
-- Authenticate to Azure platform usign Azure CLI tool. https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli
+- Authenticate to Azure platform using Azure CLI tool. https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli
 
 ## How to use:
 
@@ -21,7 +21,7 @@ The  **terraform apply**  command executes the actions proposed in a terraform t
 
 The template deploys Virtual Machine using **VHD files**:
 - One LoadCore MDW
-- Two LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Two LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 Each test interface will get 8 private IPs.
 
 The folder contains three files:
@@ -40,7 +40,7 @@ In order to modify the default values, you should modify the **terraform.tfvars*
 | ----------------------- | ----------------- | ----- |
 | prefix | Requires input |The Azure stack name. |
 | ssh_key_name | Requires input | Specify an existing Azure SSH key name. |
-| allowed_cidr | ["0.0.0.0/0"] |List of ip allowed to access the deployed machines. Default value will provide access to everyone from the internet. |
+| allowed_cidr | ["0.0.0.0/0"] |List of IPs allowed to access the deployed machines. Default value will provide access to everyone from the internet. |
 | location            | "eastus"   | The Azure region for deployment. |
 | loadcore_mdw_blob_uri     | Requires input   | The full blob uri where the vhd exists |
 | loadcore_agent_blob_uri     | Requires input   | The full blob uri where the vhd exists |

--- a/Azure/Open RAN SIM CE 5.1/terraform/deploy_LoadCore_from_Azure_Images/README.md
+++ b/Azure/Open RAN SIM CE 5.1/terraform/deploy_LoadCore_from_Azure_Images/README.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 The prerequisites are:
 - Latest version of Terraform installed. https://learn.hashicorp.com/tutorials/terraform/install-cli
-- Authenticate to Azure platform usign Azure CLI tool. https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli
+- Authenticate to Azure platform using Azure CLI tool. https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli
 
 ## How to use:
 
@@ -21,7 +21,7 @@ The  **terraform apply**  command executes the actions proposed in a terraform t
 
 The template deploys Virtual Machine using **Azure Images**:
 - One LoadCore MDW
-- Two LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Two LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 Each test interface will get 8 private IPs.
 
 The folder contains three files:
@@ -40,7 +40,7 @@ In order to modify the default values, you should modify the **terraform.tfvars*
 | ----------------------- | ----------------- | ----- |
 | prefix | Requires input |The Azure stack name. |
 | ssh_key_name | Requires input | Specify an existing Azure SSH key name. |
-| allowed_cidr | ["0.0.0.0/0"] |List of ip allowed to access the deployed machines. Default value will provide access to everyone from the internet. |
+| allowed_cidr | ["0.0.0.0/0"] |List of IPs allowed to access the deployed machines. Default value will provide access to everyone from the internet. |
 | location            | "eastus"   | The Azure region for deployment. |
 | images_resource_group_name     | Requires input   | The Azure resource group name |
 | loadcore_mdw_name     | Requires input   | The Azure Image name for LoadCore MDW |

--- a/Azure/Open RAN SIM CE 5.1/terraform/deploy_LoadCore_from_vhds/README.md
+++ b/Azure/Open RAN SIM CE 5.1/terraform/deploy_LoadCore_from_vhds/README.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 The prerequisites are:
 - Latest version of Terraform installed. https://learn.hashicorp.com/tutorials/terraform/install-cli
-- Authenticate to Azure platform usign Azure CLI tool. https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli
+- Authenticate to Azure platform using Azure CLI tool. https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli
 
 ## How to use:
 
@@ -21,7 +21,7 @@ The  **terraform apply**  command executes the actions proposed in a terraform t
 
 The template deploys Virtual Machine using **VHD files**:
 - One LoadCore MDW
-- Two LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Two LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 Each test interface will get 8 private IPs.
 
 The folder contains three files:
@@ -40,7 +40,7 @@ In order to modify the default values, you should modify the **terraform.tfvars*
 | ----------------------- | ----------------- | ----- |
 | prefix | Requires input |The Azure stack name. |
 | ssh_key_name | Requires input | Specify an existing Azure SSH key name. |
-| allowed_cidr | ["0.0.0.0/0"] |List of ip allowed to access the deployed machines. Default value will provide access to everyone from the internet. |
+| allowed_cidr | ["0.0.0.0/0"] |List of IPs allowed to access the deployed machines. Default value will provide access to everyone from the internet. |
 | location            | "eastus"   | The Azure region for deployment. |
 | loadcore_mdw_blob_uri     | Requires input   | The full blob uri where the vhd exists |
 | loadcore_agent_blob_uri     | Requires input   | The full blob uri where the vhd exists |

--- a/Azure/Open RAN SIM CE 5.2/terraform/deploy_LoadCore_from_Azure_Images/README.md
+++ b/Azure/Open RAN SIM CE 5.2/terraform/deploy_LoadCore_from_Azure_Images/README.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 The prerequisites are:
 - Latest version of Terraform installed. https://learn.hashicorp.com/tutorials/terraform/install-cli
-- Authenticate to Azure platform usign Azure CLI tool. https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli
+- Authenticate to Azure platform using Azure CLI tool. https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli
 
 ## How to use:
 
@@ -21,7 +21,7 @@ The  **terraform apply**  command executes the actions proposed in a terraform t
 
 The template deploys Virtual Machine using **Azure Images**:
 - One LoadCore MDW
-- Two LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Two LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 Each test interface will get 8 private IPs.
 
 The folder contains three files:
@@ -40,7 +40,7 @@ In order to modify the default values, you should modify the **terraform.tfvars*
 | ----------------------- | ----------------- | ----- |
 | prefix | Requires input |The Azure stack name. |
 | ssh_key_name | Requires input | Specify an existing Azure SSH key name. |
-| allowed_cidr | ["0.0.0.0/0"] |List of ip allowed to access the deployed machines. Default value will provide access to everyone from the internet. |
+| allowed_cidr | ["0.0.0.0/0"] |List of IPs allowed to access the deployed machines. Default value will provide access to everyone from the internet. |
 | location            | "eastus"   | The Azure region for deployment. |
 | images_resource_group_name     | Requires input   | The Azure resource group name |
 | loadcore_mdw_name     | Requires input   | The Azure Image name for LoadCore MDW |

--- a/Azure/Open RAN SIM CE 5.2/terraform/deploy_LoadCore_from_vhds/README.md
+++ b/Azure/Open RAN SIM CE 5.2/terraform/deploy_LoadCore_from_vhds/README.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 The prerequisites are:
 - Latest version of Terraform installed. https://learn.hashicorp.com/tutorials/terraform/install-cli
-- Authenticate to Azure platform usign Azure CLI tool. https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli
+- Authenticate to Azure platform using Azure CLI tool. https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli
 
 ## How to use:
 
@@ -21,7 +21,7 @@ The  **terraform apply**  command executes the actions proposed in a terraform t
 
 The template deploys Virtual Machine using **VHD files**:
 - One LoadCore MDW
-- Two LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Two LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 Each test interface will get 8 private IPs.
 
 The folder contains three files:
@@ -40,7 +40,7 @@ In order to modify the default values, you should modify the **terraform.tfvars*
 | ----------------------- | ----------------- | ----- |
 | prefix | Requires input |The Azure stack name. |
 | ssh_key_name | Requires input | Specify an existing Azure SSH key name. |
-| allowed_cidr | ["0.0.0.0/0"] |List of ip allowed to access the deployed machines. Default value will provide access to everyone from the internet. |
+| allowed_cidr | ["0.0.0.0/0"] |List of IPs allowed to access the deployed machines. Default value will provide access to everyone from the internet. |
 | location            | "eastus"   | The Azure region for deployment. |
 | loadcore_mdw_blob_uri     | Requires input   | The full blob uri where the vhd exists |
 | loadcore_agent_blob_uri     | Requires input   | The full blob uri where the vhd exists |

--- a/Azure/Open RAN SIM CE 6.0/terraform/deploy_LoadCore_from_Azure_Images/README.md
+++ b/Azure/Open RAN SIM CE 6.0/terraform/deploy_LoadCore_from_Azure_Images/README.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 The prerequisites are:
 - Latest version of Terraform installed. https://learn.hashicorp.com/tutorials/terraform/install-cli
-- Authenticate to Azure platform usign Azure CLI tool. https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli
+- Authenticate to Azure platform using Azure CLI tool. https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli
 
 ## How to use:
 
@@ -21,7 +21,7 @@ The  **terraform apply**  command executes the actions proposed in a terraform t
 
 The template deploys Virtual Machine using **Azure Images**:
 - One LoadCore MDW
-- Two LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Two LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 Each test interface will get 8 private IPs.
 
 The folder contains three files:
@@ -40,7 +40,7 @@ In order to modify the default values, you should modify the **terraform.tfvars*
 | ----------------------- | ----------------- | ----- |
 | prefix | Requires input |The Azure stack name. |
 | ssh_key_name | Requires input | Specify an existing Azure SSH key name. |
-| allowed_cidr | ["0.0.0.0/0"] |List of ip allowed to access the deployed machines. Default value will provide access to everyone from the internet. |
+| allowed_cidr | ["0.0.0.0/0"] |List of IPs allowed to access the deployed machines. Default value will provide access to everyone from the internet. |
 | location            | "eastus"   | The Azure region for deployment. |
 | images_resource_group_name     | Requires input   | The Azure resource group name |
 | loadcore_mdw_name     | Requires input   | The Azure Image name for LoadCore MDW |

--- a/Azure/Open RAN SIM CE 6.0/terraform/deploy_LoadCore_from_vhds/README.md
+++ b/Azure/Open RAN SIM CE 6.0/terraform/deploy_LoadCore_from_vhds/README.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 The prerequisites are:
 - Latest version of Terraform installed. https://learn.hashicorp.com/tutorials/terraform/install-cli
-- Authenticate to Azure platform usign Azure CLI tool. https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli
+- Authenticate to Azure platform using Azure CLI tool. https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli
 
 ## How to use:
 
@@ -21,7 +21,7 @@ The  **terraform apply**  command executes the actions proposed in a terraform t
 
 The template deploys Virtual Machine using **VHD files**:
 - One LoadCore MDW
-- Two LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Two LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 Each test interface will get 8 private IPs.
 
 The folder contains three files:
@@ -40,7 +40,7 @@ In order to modify the default values, you should modify the **terraform.tfvars*
 | ----------------------- | ----------------- | ----- |
 | prefix | Requires input |The Azure stack name. |
 | ssh_key_name | Requires input | Specify an existing Azure SSH key name. |
-| allowed_cidr | ["0.0.0.0/0"] |List of ip allowed to access the deployed machines. Default value will provide access to everyone from the internet. |
+| allowed_cidr | ["0.0.0.0/0"] |List of IPs allowed to access the deployed machines. Default value will provide access to everyone from the internet. |
 | location            | "eastus"   | The Azure region for deployment. |
 | loadcore_mdw_blob_uri     | Requires input   | The full blob uri where the vhd exists |
 | loadcore_agent_blob_uri     | Requires input   | The full blob uri where the vhd exists |

--- a/VMware/ESXi/Open RAN SIM CE 1.0/Deployment Tools/terraform/loadcore_mdw_two_agents/README.md
+++ b/VMware/ESXi/Open RAN SIM CE 1.0/Deployment Tools/terraform/loadcore_mdw_two_agents/README.md
@@ -2,7 +2,7 @@
 
 The template deploys:
 - One LoadCore in the specified management network
-- Two LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Two LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 
 The folder contains three files:
 

--- a/VMware/ESXi/Open RAN SIM CE 1.0/Deployment Tools/terraform/multiple_agents/README.md
+++ b/VMware/ESXi/Open RAN SIM CE 1.0/Deployment Tools/terraform/multiple_agents/README.md
@@ -1,7 +1,7 @@
 ### One LoadCore MDW and two LoadCore Agents
 
 The template deploys:
-- Multiple LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Multiple LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 
 The folder contains three files:
 

--- a/VMware/ESXi/Open RAN SIM CE 1.0/Deployment Tools/terraform/two_agents/README.md
+++ b/VMware/ESXi/Open RAN SIM CE 1.0/Deployment Tools/terraform/two_agents/README.md
@@ -1,7 +1,7 @@
 ### One LoadCore MDW and two LoadCore Agents
 
 The template deploys:
-- Two LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Two LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 
 The folder contains three files:
 

--- a/VMware/ESXi/Open RAN SIM CE 2.0/Deployment Tools/terraform/loadcore_mdw_two_agents/README.md
+++ b/VMware/ESXi/Open RAN SIM CE 2.0/Deployment Tools/terraform/loadcore_mdw_two_agents/README.md
@@ -2,7 +2,7 @@
 
 The template deploys:
 - One LoadCore in the specified management network
-- Two LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Two LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 
 The folder contains three files:
 

--- a/VMware/ESXi/Open RAN SIM CE 2.0/Deployment Tools/terraform/multiple_agents/README.md
+++ b/VMware/ESXi/Open RAN SIM CE 2.0/Deployment Tools/terraform/multiple_agents/README.md
@@ -1,7 +1,7 @@
 ### One LoadCore MDW and two LoadCore Agents
 
 The template deploys:
-- Multiple LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Multiple LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 
 The folder contains three files:
 

--- a/VMware/ESXi/Open RAN SIM CE 2.0/Deployment Tools/terraform/two_agents/README.md
+++ b/VMware/ESXi/Open RAN SIM CE 2.0/Deployment Tools/terraform/two_agents/README.md
@@ -1,7 +1,7 @@
 ### One LoadCore MDW and two LoadCore Agents
 
 The template deploys:
-- Two LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Two LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 
 The folder contains three files:
 

--- a/VMware/ESXi/Open RAN SIM CE 3.0/Deployment Tools/terraform/loadcore_mdw_two_agents/README.md
+++ b/VMware/ESXi/Open RAN SIM CE 3.0/Deployment Tools/terraform/loadcore_mdw_two_agents/README.md
@@ -2,7 +2,7 @@
 
 The template deploys:
 - One LoadCore in the specified management network
-- Two LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Two LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 
 The folder contains three files:
 

--- a/VMware/ESXi/Open RAN SIM CE 3.0/Deployment Tools/terraform/multiple_agents/README.md
+++ b/VMware/ESXi/Open RAN SIM CE 3.0/Deployment Tools/terraform/multiple_agents/README.md
@@ -1,7 +1,7 @@
 ### One LoadCore MDW and two LoadCore Agents
 
 The template deploys:
-- Multiple LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Multiple LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 
 The folder contains three files:
 

--- a/VMware/ESXi/Open RAN SIM CE 3.0/Deployment Tools/terraform/two_agents/README.md
+++ b/VMware/ESXi/Open RAN SIM CE 3.0/Deployment Tools/terraform/two_agents/README.md
@@ -1,7 +1,7 @@
 ### One LoadCore MDW and two LoadCore Agents
 
 The template deploys:
-- Two LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Two LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 
 The folder contains three files:
 

--- a/VMware/ESXi/Open RAN SIM CE 5.0/Deployment Tools/terraform/loadcore_mdw_two_agents/README.md
+++ b/VMware/ESXi/Open RAN SIM CE 5.0/Deployment Tools/terraform/loadcore_mdw_two_agents/README.md
@@ -2,7 +2,7 @@
 
 The template deploys:
 - One LoadCore in the specified management network
-- Two LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Two LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 
 The folder contains three files:
 

--- a/VMware/ESXi/Open RAN SIM CE 5.0/Deployment Tools/terraform/multiple_agents/README.md
+++ b/VMware/ESXi/Open RAN SIM CE 5.0/Deployment Tools/terraform/multiple_agents/README.md
@@ -1,7 +1,7 @@
 ### One LoadCore MDW and two LoadCore Agents
 
 The template deploys:
-- Multiple LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Multiple LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 
 The folder contains three files:
 

--- a/VMware/ESXi/Open RAN SIM CE 5.0/Deployment Tools/terraform/two_agents/README.md
+++ b/VMware/ESXi/Open RAN SIM CE 5.0/Deployment Tools/terraform/two_agents/README.md
@@ -1,7 +1,7 @@
 ### One LoadCore MDW and two LoadCore Agents
 
 The template deploys:
-- Two LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Two LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 
 The folder contains three files:
 

--- a/VMware/ESXi/Open RAN SIM CE 5.1/Deployment Tools/terraform/loadcore_mdw_two_agents/README.md
+++ b/VMware/ESXi/Open RAN SIM CE 5.1/Deployment Tools/terraform/loadcore_mdw_two_agents/README.md
@@ -2,7 +2,7 @@
 
 The template deploys:
 - One LoadCore in the specified management network
-- Two LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Two LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 
 The folder contains three files:
 

--- a/VMware/ESXi/Open RAN SIM CE 5.1/Deployment Tools/terraform/multiple_agents/README.md
+++ b/VMware/ESXi/Open RAN SIM CE 5.1/Deployment Tools/terraform/multiple_agents/README.md
@@ -1,7 +1,7 @@
 ### One LoadCore MDW and two LoadCore Agents
 
 The template deploys:
-- Multiple LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Multiple LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 
 The folder contains three files:
 

--- a/VMware/ESXi/Open RAN SIM CE 5.1/Deployment Tools/terraform/two_agents/README.md
+++ b/VMware/ESXi/Open RAN SIM CE 5.1/Deployment Tools/terraform/two_agents/README.md
@@ -1,7 +1,7 @@
 ### One LoadCore MDW and two LoadCore Agents
 
 The template deploys:
-- Two LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Two LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 
 The folder contains three files:
 

--- a/VMware/ESXi/Open RAN SIM CE 5.2/Deployment Tools/terraform/loadcore_mdw_two_agents/README.md
+++ b/VMware/ESXi/Open RAN SIM CE 5.2/Deployment Tools/terraform/loadcore_mdw_two_agents/README.md
@@ -2,7 +2,7 @@
 
 The template deploys:
 - One LoadCore in the specified management network
-- Two LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Two LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 
 The folder contains three files:
 

--- a/VMware/ESXi/Open RAN SIM CE 5.2/Deployment Tools/terraform/multiple_agents/README.md
+++ b/VMware/ESXi/Open RAN SIM CE 5.2/Deployment Tools/terraform/multiple_agents/README.md
@@ -1,7 +1,7 @@
 ### One LoadCore MDW and two LoadCore Agents
 
 The template deploys:
-- Multiple LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Multiple LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 
 The folder contains three files:
 

--- a/VMware/ESXi/Open RAN SIM CE 5.2/Deployment Tools/terraform/two_agents/README.md
+++ b/VMware/ESXi/Open RAN SIM CE 5.2/Deployment Tools/terraform/two_agents/README.md
@@ -1,7 +1,7 @@
 ### One LoadCore MDW and two LoadCore Agents
 
 The template deploys:
-- Two LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Two LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 
 The folder contains three files:
 

--- a/VMware/ESXi/Open RAN SIM CE 6.0/Deployment Tools/terraform/loadcore_mdw_two_agents/README.md
+++ b/VMware/ESXi/Open RAN SIM CE 6.0/Deployment Tools/terraform/loadcore_mdw_two_agents/README.md
@@ -2,7 +2,7 @@
 
 The template deploys:
 - One LoadCore in the specified management network
-- Two LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Two LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 
 The folder contains three files:
 

--- a/VMware/ESXi/Open RAN SIM CE 6.0/Deployment Tools/terraform/multiple_agents/README.md
+++ b/VMware/ESXi/Open RAN SIM CE 6.0/Deployment Tools/terraform/multiple_agents/README.md
@@ -1,7 +1,7 @@
 ### One LoadCore MDW and two LoadCore Agents
 
 The template deploys:
-- Multiple LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Multiple LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 
 The folder contains three files:
 

--- a/VMware/ESXi/Open RAN SIM CE 6.0/Deployment Tools/terraform/two_agents/README.md
+++ b/VMware/ESXi/Open RAN SIM CE 6.0/Deployment Tools/terraform/two_agents/README.md
@@ -1,7 +1,7 @@
 ### One LoadCore MDW and two LoadCore Agents
 
 The template deploys:
-- Two LoadCore Agents with three interfaces each. The first interface will be used for mananagament and the rest of the interfaces will be used for testing
+- Two LoadCore Agents with three interfaces each. The first interface will be used for management and the rest of the interfaces will be used for testing
 
 The folder contains three files:
 


### PR DESCRIPTION
## Summary

Fix 7 recurring misspellings across 45 README files in AWS, Azure, and VMware deployment documentation:

- `mananagament` → `management` (45 files)
- `usign` → `using` (14 files)
- `LoadCode` → `LoadCore` (product name typo, 7 files)
- `List of ip` → `List of IPs` (16 files)
- `prevent the licenses to remain activated` → `prevent the licenses from remaining activated` (8 files)
- `Security Groups that allows` → `Security Groups that allow` (1 file)
- `accessing to LoadCore` → `accessing LoadCore` (1 file)

No functional changes — documentation only.